### PR TITLE
Support .desktop file in /usr/share/applications.

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -12,6 +12,9 @@ pycharm:
     #Enable Debian alternatives feature by setting nonzero 'altpriority' value here.
     #Increase same value on each subsequent software installation.
     altpriority: 0
+    #Place a .desktop file in /usr/share/applications (default is True)
+    #This makes PyCharm show up in e.g. Gnome's launcher.
+    install_desktop_file: True
   prefs:
     user: undefined_user
     #See https://www.jetbrains.com/help/pycharm/exporting-and-importing-settings.html

--- a/pillar.example
+++ b/pillar.example
@@ -12,9 +12,10 @@ pycharm:
     #Enable Debian alternatives feature by setting nonzero 'altpriority' value here.
     #Increase same value on each subsequent software installation.
     altpriority: 0
-    #Place a .desktop file in /usr/share/applications (default is True)
+    #Place a .desktop file in e.g. /usr/share/applications (default is True)
     #This makes PyCharm show up in e.g. Gnome's launcher.
     install_desktop_file: True
+    desktop_file: /usr/share/applications/pycharm.desktop
   prefs:
     user: undefined_user
     #See https://www.jetbrains.com/help/pycharm/exporting-and-importing-settings.html

--- a/pycharm/defaults.yaml
+++ b/pycharm/defaults.yaml
@@ -29,6 +29,8 @@ pycharm:
     symlink: /usr/bin/pycharm
     #debian alternatives is disabled by default. Activated via pillar value.
     altpriority: 0
+    #Place .desktop file for showing PyCharm in e.g. Gnome's launcher.
+    install_desktop_file: True
 
   prefs:
     user:

--- a/pycharm/defaults.yaml
+++ b/pycharm/defaults.yaml
@@ -31,6 +31,7 @@ pycharm:
     altpriority: 0
     #Place .desktop file for showing PyCharm in e.g. Gnome's launcher.
     install_desktop_file: True
+    desktop_file: /usr/share/applications/pycharm.desktop
 
   prefs:
     user:

--- a/pycharm/linuxenv.sls
+++ b/pycharm/linuxenv.sls
@@ -61,4 +61,18 @@ pycharm-alt-set:
 
   {% endif %}
 
+# Place .desktop file in /usr/share/applications
+# This makes pycharm show up in e.g. Gnome's launcher.
+  {% if pycharm.linux.install_desktop_file %}
+pycharm-global-desktop-file:
+  file.managed:
+    - name: /usr/share/applications/pycharm.desktop
+    - source: salt://pycharm/files/pycharm.desktop
+    - template: jinja
+    - context:
+      home: {{ pycharm.jetbrains.realhome }}
+      command: {{ pycharm.command }}
+      edition: {{ pycharm.jetbrains.edition }}
+  {% endif %}
+
 {% endif %}

--- a/pycharm/linuxenv.sls
+++ b/pycharm/linuxenv.sls
@@ -66,7 +66,7 @@ pycharm-alt-set:
   {% if pycharm.linux.install_desktop_file %}
 pycharm-global-desktop-file:
   file.managed:
-    - name: /usr/share/applications/pycharm.desktop
+    - name: {{ pycharm.linux.desktop_file }}
     - source: salt://pycharm/files/pycharm.desktop
     - template: jinja
     - context:


### PR DESCRIPTION
As discussed in #3, this adds placing pycharm.desktop in /usr/share/applications for availability to tools like Gnome's launcher. Can be disabled via pillar, if desired.