### PR TITLE
Always retry alternatives.install states

### DIFF
--- a/pycharm/linuxenv.sls
+++ b/pycharm/linuxenv.sls
@@ -31,6 +31,9 @@ pycharm-home-alt-install:
     - link: '{{ pycharm.jetbrains.home }}/pycharm'
     - path: '{{ pycharm.jetbrains.realhome }}'
     - priority: {{ pycharm.linux.altpriority }}
+    - retry:
+        attempts: 3
+        until: True
 
 pycharm-home-alt-set:
   alternatives.set:
@@ -40,6 +43,9 @@ pycharm-home-alt-set:
       - alternatives: pycharm-home-alt-install
     - onchanges:
       - alternatives: pycharm-home-alt-install
+    - retry:
+        attempts: 3
+        until: True
 
 # Add to alternatives system
 pycharm-alt-install:
@@ -51,6 +57,9 @@ pycharm-alt-install:
     - require:
       - alternatives: pycharm-home-alt-install
       - alternatives: pycharm-home-alt-set
+    - retry:
+        attempts: 3
+        until: True
 
 pycharm-alt-set:
   alternatives.set:
@@ -58,6 +67,9 @@ pycharm-alt-set:
     - path: {{ pycharm.jetbrains.realcmd }}
     - onchanges:
       - alternatives: pycharm-alt-install
+    - retry:
+        attempts: 3
+        until: True
 
   {% endif %}
 

--- a/pycharm/map.jinja
+++ b/pycharm/map.jinja
@@ -16,7 +16,8 @@
 ) %}
 
 # Get dynamic release metadata
-{%- set pcode = ide.jetbrains.product ~ ide.jetbrains.edition %}
+{%- set pcode = ide.jetbrains.product %}
+{%- set pcode = pcode ~ ide.jetbrains.edition if ide.jetbrains.edition else pcode %}
 {%- set jdata = salt['cmd.run']('curl {0} -s {1}{2}'.format(ide.dl.opts, ide.jetbrains.uri, pcode))|load_yaml %}
 {%- set _home = '{0}/pycharm-{1}-{2}'.format( ide.prefix, ide.jetbrains.edition, jdata[ pcode ][0]['version'],) %}
 {%- if grains.os == 'MacOS' %}


### PR DESCRIPTION
This PR introduces retries because salt `alternatives.install` fails on 1st run.

Verified on SuSE
```
ID: pycharm-home-alt-install
    Function: alternatives.install
        Name: pycharm-home
      Result: True
     Comment: Attempt 1: Returned a result of "False", with the following comment: "Alternative for pycharm-home not installed: update-alternatives: using /usr/local/jetbrains/pycharm-C-2019.1.1 to provide /opt/jetbrains/pycharm (pycharm-home) in auto mode"
              Alternatives for pycharm-home is already set to /usr/local/jetbrains/pycharm-C-2019.1.1
     Started: 22:14:10.193665
    Duration: 30008.223 ms
     Changes:   
----------
          ID: pycharm-home-alt-set
    Function: alternatives.set
        Name: pycharm-home
      Result: True
     Comment: State was not run because none of the onchanges reqs changed
     Changes:   
----------
          ID: pycharm-alt-install
    Function: alternatives.install
        Name: pycharm
      Result: True
     Comment: Attempt 1: Returned a result of "False", with the following comment: "Alternative for pycharm not installed: update-alternatives: using /usr/local/jetbrains/pycharm-C-2019.1.1/bin/pycharm.sh to provide /usr/bin/pycharm (pycharm) in auto mode"
              Alternatives for pycharm is already set to /usr/local/jetbrains/pycharm-C-2019.1.1/bin/pycharm.sh
     Started: 22:14:40.234327
    Duration: 30015.3 ms
     Changes:   
----------
          ID: pycharm-alt-set
    Function: alternatives.set
        Name: pycharm
      Result: True
     Comment: State was not run because none of the onchanges reqs changed
     Changes:   
```